### PR TITLE
Fix: Fix worker_threads support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "remote_path": "./cache/sqlite3/v{version}/{toolset}/",
     "package_name": "napi-v{napi_build_version}-{platform}-{arch}-{libc}.tar.gz",
     "napi_versions": [
-      3
+      6
     ]
   },
   "contributors": [


### PR DESCRIPTION
Surprise, I think this is the only change needed to get it working!

In [node-sqlite3#1367](https://github.com/mapbox/node-sqlite3/pull/1367), you can see that they already fixed it by implementing `NAPI v6`. Then in [node-sqlite3#1444](https://github.com/mapbox/node-sqlite3/issues/1444), you can see that they delayed deploying this fix only because their build process is broken. Since we don't need to support older node versions, we can just skip building for `NAPI v3` entirely.

I tested a few add / delete monitor in uptime-kuma and the v6 version seems to work fine. `npm run test` also passed, although I'm not sure how the tests work.

Closes [uptime-kuma#574](https://github.com/louislam/uptime-kuma/issues/574)